### PR TITLE
Bump Golang to 1.10.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM    golang:1.10.2
+FROM    golang:1.10.3
 
 # allow replacing httpredir or deb mirror
 ARG     APT_MIRROR=deb.debian.org


### PR DESCRIPTION
go1.10.3 (released 2018/06/05) includes fixes to the go command, and the
crypto/tls, crypto/x509, and strings packages. In particular, it adds minimal
support to the go command for the vgo transition. See the Go 1.10.3 milestone
on our issue tracker for details;
https://github.com/golang/go/issues?q=milestone%3AGo1.10.3

