### PR TITLE
Bump Go to 1.10.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM    golang:1.10.3
+FROM    golang:1.10.4
 
 # allow replacing httpredir or deb mirror
 ARG     APT_MIRROR=deb.debian.org


### PR DESCRIPTION
Includes fixes to the go command, linker, and the net/http, mime/multipart,
ld/macho, bytes, and strings packages. See the Go 1.10.4 milestone on the
issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.10.4
