### PR TITLE
Bump Go to 1.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM    golang:1.10.4
+FROM    golang:1.11.0
 
 # allow replacing httpredir or deb mirror
 ARG     APT_MIRROR=deb.debian.org


### PR DESCRIPTION
Release notes: https://golang.org/doc/go1.11


This PR is created on top of https://github.com/docker/golang-cross/pull/8, which should be merged (and tagged) first 👍 