### PR TITLE
osx fixes for go 1.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM    golang:1.11.0
 ARG     APT_MIRROR=deb.debian.org
 RUN     sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
-RUN     apt-get update -qq && apt-get install -y -q \
+RUN     apt-get update -qq && apt-get install -y -q --no-install-recommends \
             libltdl-dev \
             gcc-mingw-w64 \
             parallel \

--- a/osx-cross.sh
+++ b/osx-cross.sh
@@ -14,6 +14,7 @@ time apt-get install -y -q --no-install-recommends $PKG_DEPS
 # NOTE: when changing version here, make sure to
 # also change OSX_CODENAME below to match
 OSX_SDK=MacOSX10.10.sdk
+SDK_SUM=631b4144c6bf75bf7a4d480d685a9b5bda10ee8d03dbf0db829391e2ef858789
 
 OSX_CROSS_COMMIT=a9317c18a3a457ca0a657f08cc4d0d43c6cf8953
 OSXCROSS_PATH="/osxcross"
@@ -29,6 +30,9 @@ git checkout -q $OSX_CROSS_COMMIT
 echo "Downloading OSX SDK"
 time curl -sSL https://s3.dockerproject.org/darwin/v2/${OSX_SDK}.tar.xz \
     -o "${OSXCROSS_PATH}/tarballs/${OSX_SDK}.tar.xz"
+
+echo "$SDK_SUM  ${OSXCROSS_PATH}/tarballs/${OSX_SDK}.tar.xz" \
+	| sha256sum -c -
 
 echo "Building osxcross"
 # Go 1.11 requires OSX >= 10.10


### PR DESCRIPTION
This is a 3-in-1 story. Please have a seat.

### Part 1.

Go 1.11 release notes say:

> Go 1.11 now requires <...> macOS 10.10 Yosemite or later

So, change the `OSX_VERSION_MIN` in `osxcross` to `10.10`.

### Part 2.

MACOSX SDK tarball that was used before comes without libc++
headers, which are now required by at least crypto/x509 pkg
when compiling for Darwin. These include files are part of xcode,
which can only be downloaded by someone having Apple Developer ID,
which I don't have so this path is not available for me.

An alternative is to reuse the SDK tarball from the
https://github.com/multiarch/crossbuild project. Using it
fixes the following error:

```
# crypto/x509
osxcross: error: cannot find libc++ headers
```

### Part 3.

The new tarball, although, misses the libtool package (apparently
somehow injected into the tarball that was used earlier) needed to
compile miekg/pkcs11 used by cli, which leads to errors like:

```
# github.com/docker/cli/vendor/github.com/miekg/pkcs11
vendor/github.com/miekg/pkcs11/pkcs11.go:28:10: fatal error: 'ltdl.h' file not found
#include <ltdl.h>
          ^
1 error generated.
```

To fix this one, libtool for osx need to be installed. Building it from
source (with osxcross) requires some other dependencies. Using brew is not
possible since it is Linux. Solution: download a binary package from brew
repo, cherry pick the needed stuff (lib and include).

Tested to fix docker-cli compilation issues on OSX using Go 1.11.