### PR TITLE
Bump Go to 1.11.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM    golang:1.11.1
+FROM    golang:1.11.2
 
 # allow replacing httpredir or deb mirror
 ARG     APT_MIRROR=deb.debian.org


### PR DESCRIPTION
go1.11.2 (released 2018/11/02) includes fixes to the compiler, linker,
documentation, go command, and the database/sql and go/types packages.

See the milestone on the issue tracker for details:
https://github.com/golang/go/issues?q=milestone%3AGo1.11.2

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>