### PR TITLE
Bump Golang 1.11.3 (CVE-2018-16875)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM    golang:1.11.2
+FROM    golang:1.11.3
 
 # allow replacing httpredir or deb mirror
 ARG     APT_MIRROR=deb.debian.org


### PR DESCRIPTION
go1.11.13 (released 2018/12/14)

- crypto/x509: CPU denial of service in chain validation golang/go#29233
- cmd/go: directory traversal in "go get" via curly braces in import paths golang/go#29231
- cmd/go: remote command execution during "go get -u" golang/go#29230

See the Go 1.11.3 milestone on the issue tracker for details:
https://github.com/golang/go/issues?q=milestone%3AGo1.11.3

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>