### PR TITLE
Bump Golang 1.10.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM    golang:1.10.6
+FROM    golang:1.10.7
 
 # allow replacing httpredir or deb mirror
 ARG     APT_MIRROR=deb.debian.org


### PR DESCRIPTION
go1.10.7 (released 2018/12/14) includes a fix to a bug introduced in Go 1.10.6
that broke go get for import path patterns containing "...".

See the Go 1.10.7 milestone for details:
https://github.com/golang/go/issues?q=milestone%3AGo1.10.7+label%3ACherryPickApproved
