### PR TITLE
Bump Golang 1.11.5 (CVE-2019-6486)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM    golang:1.11.4
+FROM    golang:1.11.5
 
 # allow replacing httpredir or deb mirror
 ARG     APT_MIRROR=deb.debian.org


### PR DESCRIPTION
See the milestone for details;
https://github.com/golang/go/issues?q=milestone%3AGo1.11.5+label%3ACherryPickApproved

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>