### PR TITLE
Bump Golang 1.12.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM    golang:1.11.5
+FROM    golang:1.12.0
 
 # allow replacing httpredir or deb mirror
 ARG     APT_MIRROR=deb.debian.org


### PR DESCRIPTION
release notes: https://golang.org/doc/go1.12


note that there's still a regression in Go 1.12.0 for Windows (https://github.com/golang/go/issues/30307#issuecomment-467773906) which will be addressed in Go 1.12.1, but we can build this image already to start testing Go 1.12.0 on docker/cli
