### PR TITLE
Bump Golang 1.12.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM    golang:1.12.0
+FROM    golang:1.12.1
 
 # allow replacing httpredir or deb mirror
 ARG     APT_MIRROR=deb.debian.org


### PR DESCRIPTION
go1.12.1 (released 2019/03/14) includes fixes to cgo, the compiler,
the go command, and the fmt, net/smtp, os, path/filepath, sync, and
text/template packages. See the Go 1.12.1 milestone on our issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.12.1
