### PR TITLE
Bump Golang 1.11.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM    golang:1.11.6
+FROM    golang:1.11.7
 
 # allow replacing httpredir or deb mirror
 ARG     APT_MIRROR=deb.debian.org


### PR DESCRIPTION
go1.11.7 (released 2019/04/05) includes fixes to the runtime and the net
packages. See the Go 1.11.7 milestone on our issue tracker for details.

https://github.com/golang/go/issues?q=milestone%3AGo1.11.7

Full diff: https://github.com/golang/go/compare/go1.11.6...go1.11.7
