### PR TITLE
Bump Golang 1.12.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM    golang:1.12.1
+FROM    golang:1.12.2
 
 # allow replacing httpredir or deb mirror
 ARG     APT_MIRROR=deb.debian.org


### PR DESCRIPTION
go1.12.2 (released 2019/04/05) includes fixes to the compiler, the go
command, the runtime, and the doc, net, net/http/httputil, and os packages.
See the Go 1.12.2 milestone on our issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.12.2

Full diff: https://github.com/golang/go/compare/go1.12.1...go1.12.2
