### PR TITLE
Bump Golang 1.11.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM    golang:1.11.7
+FROM    golang:1.11.8
 
 # allow replacing httpredir or deb mirror
 ARG     APT_MIRROR=deb.debian.org


### PR DESCRIPTION
go1.11.8 (released 2019/04/08) fixes an issue where using the prebuilt binary
releases on older versions of GNU/Linux led to failures when linking programs
that used cgo. Only Linux users who hit this issue need to update.

See https://github.com/golang/go/issues/31293 for details

Full diff: https://github.com/golang/go/compare/go1.11.7...go1.11.8
