### PR TITLE
Bump golang 1.12.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM    golang:1.12.4
+FROM    golang:1.12.5
 
 # allow replacing httpredir or deb mirror
 ARG     APT_MIRROR=deb.debian.org


### PR DESCRIPTION
Signed-off-by: Jintao Zhang <zhangjt@rd.netease.com>

go1.12.5 (released 2019/05/06) includes fixes to the compiler, the linker,
the go command, the runtime, and the <code>os</code> package. See the
<a href="https://github.com/golang/go/issues?q=milestone%3AGo1.12.5">Go 1.12.5 milestone</a> on our issue tracker for details.

https://github.com/golang/go/compare/go1.12.4...go1.12.5
