### PR TITLE
Bump Golang 1.11.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM    golang:1.11.9
+FROM    golang:1.11.10
 
 # allow replacing httpredir or deb mirror
 ARG     APT_MIRROR=deb.debian.org


### PR DESCRIPTION
go1.11.10 (released 2019/05/06) includes fixes to the runtime and the linker.
See the Go 1.11.10 milestone on our issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.11.10

Full diff: https://github.com/golang/go/compare/go1.11.9...go1.11.10
