### PR TITLE
bump golang 1.12.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM    golang:1.12.5
+FROM    golang:1.12.6
 
 # allow replacing httpredir or deb mirror
 ARG     APT_MIRROR=deb.debian.org


### PR DESCRIPTION
Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>

go1.12.6 (released 2019/06/11) includes fixes to the compiler, the linker,
the go command, and the <code>crypto/x509</code>, <code>net/http</code>, and
<code>os</code> packages. See the<a href="https://github.com/golang/go/issues?q=milestone%3AGo1.12.6">Go 1.12.6 milestone</a> on our issue tracker for details.

https://github.com/golang/go/compare/go1.12.5...go1.12.6

and wait for docker-library/official-images#6070 been merged.


