### PR TITLE
Bump golang 1.11.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM    golang:1.11.10
+FROM    golang:1.11.11
 
 # allow replacing httpredir or deb mirror
 ARG     APT_MIRROR=deb.debian.org


### PR DESCRIPTION
go1.11.11 (released 2019/06/11) includes a fix to the crypto/x509 package.
See the Go 1.11.11 milestone on the issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.11.11

full diff: https://github.com/golang/go/compare/go1.11.10...go1.11.11
