### PR TITLE
bump golang 1.12.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM    golang:1.12.6
+FROM    golang:1.12.7
 
 # allow replacing httpredir or deb mirror
 ARG     APT_MIRROR=deb.debian.org


### PR DESCRIPTION
Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>

go1.12.7 (released 2019/07/08) includes fixes to cgo, the compiler,
and the linker.
See the <a href="https://github.com/golang/go/issues?q=milestone%3AGo1.12.7">Go 1.12.7 milestone</a> on our issue tracker for details.

https://github.com/golang/go/compare/go1.12.6...go1.12.7