### PR TITLE
Bump golang 1.11.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM    golang:1.11.11
+FROM    golang:1.11.12
 
 # allow replacing httpredir or deb mirror
 ARG     APT_MIRROR=deb.debian.org


### PR DESCRIPTION
go1.11.12 (released 2019/07/08) includes fixes to the compiler and the linker.
See the <a href="https://github.com/golang/go/issues?q=milestone%3AGo1.11.12">Go
1.11.12 milestone</a> on our issue tracker for details.

https://github.com/golang/go/compare/go1.11.11...go1.11.12