### PR TITLE
Bump golang 1.12.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM    golang:1.12.8
+FROM    golang:1.12.9
 
 # allow replacing httpredir or deb mirror
 ARG     APT_MIRROR=deb.debian.org


### PR DESCRIPTION
Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>

go1.12.9 (released 2019/08/15) includes fixes to the linker,
and the <code>os</code> and <code>math/big</code> packages.
See the <a href="https://github.com/golang/go/issues?q=milestone%3AGo1.12.9+label%3ACherryPickApproved">Go
1.12.9 milestone</a> on our issue tracker for details.

Full diff https://github.com/golang/go/compare/go1.12.8...go1.12.9