### PR TITLE
Declare GOPROXY to disable proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,3 +13,4 @@ RUN     apt-get update -qq && apt-get install -y -q --no-install-recommends \
 COPY    osx-cross.sh /tmp/
 RUN     /tmp/osx-cross.sh
 ENV     PATH /osxcross/target/bin:$PATH
+ENV     GOPROXY direct


### PR DESCRIPTION
this is mostly to anticipate go 1.13 which will default to proxy.golang.org

see https://arslan.io/2019/08/02/why-you-should-use-a-go-module-proxy/