### PR TITLE
[Do not merge] debugging building with OSX_VERSION_MIN=10.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM    golang:1.13.0
+FROM    golang:1.13.0-buster
 
 # allow replacing httpredir or deb mirror
 ARG     APT_MIRROR=deb.debian.org

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM    golang:1.12.9
+FROM    golang:1.13.0
 
 # allow replacing httpredir or deb mirror
 ARG     APT_MIRROR=deb.debian.org

--- a/osx-cross.sh
+++ b/osx-cross.sh
@@ -35,8 +35,8 @@ echo "$SDK_SUM  ${OSXCROSS_PATH}/tarballs/${OSX_SDK}.tar.xz" \
 	| sha256sum -c -
 
 echo "Building osxcross"
-# Go 1.11 requires OSX >= 10.10
-UNATTENDED=yes OSX_VERSION_MIN=10.10 ${OSXCROSS_PATH}/build.sh > /dev/null
+# Go 1.13 requires OSX >= 10.11
+UNATTENDED=yes OSX_VERSION_MIN=10.11 ${OSXCROSS_PATH}/build.sh > /dev/null
 
 echo "Installing libtool from brew"
 curl -sSL https://homebrew.bintray.com/bottles/libtool-${LIBTOOL_VERSION}.${OSX_CODENAME}.bottle.tar.gz \

--- a/osx-cross.sh
+++ b/osx-cross.sh
@@ -7,20 +7,56 @@
 
 set -eu -o pipefail
 
-PKG_DEPS="patch xz-utils clang llvm file"
-
-time apt-get install -y -q --no-install-recommends $PKG_DEPS
+# Based on the README at https://github.com/tpoechtrager/osxcross:
+# https://github.com/tpoechtrager/osxcross/blob/d39ba022313f2d5a1f5d02caaa1efb23d07a559b/README.md
+#
+# ensure you have the following installed on your system:
+#
+# Clang 3.4+, cmake, git, patch, Python, libssl-devel (openssl)
+# lzma-devel, libxml2-devel and the bash shell.
+#
+# You can run 'sudo tools/get_dependencies.sh' to get these (and the optional packages) automatically. (outdated)
+#
+# Optional:
+# - llvm-devel: For Link Time Optimization support
+# - llvm-devel: For ld64 -bitcode_bundle support
+# - uuid-devel: For ld64 -random_uuid support
+#
+# TODO for testing, also added dependencies that were installed by the get_dependencies.sh script (but it's mentioned to be "outdated"
+# https://github.com/tpoechtrager/osxcross/blob/d39ba022313f2d5a1f5d02caaa1efb23d07a559b/tools/get_dependencies.sh#L43-L47
+time apt-get install -y -q --no-install-recommends \
+   bzip2 \
+   clang \
+   cmake \
+   cpio \
+   file \
+   gzip \
+   libbz2-dev \
+   liblzma-dev \
+   libssl-dev \
+   libxml2-dev \
+   llvm \
+   make \
+   patch \
+   sed \
+   tar \
+   xz-utils \
+   zlib1g-dev \
+   \
+   llvm-dev \
+   uuid-dev \
+&& rm -rf /var/lib/apt/lists/*
 
 # NOTE: when changing version here, make sure to
 # also change OSX_CODENAME below to match
 OSX_SDK=MacOSX10.10.sdk
 SDK_SUM=631b4144c6bf75bf7a4d480d685a9b5bda10ee8d03dbf0db829391e2ef858789
 
-OSX_CROSS_COMMIT=a9317c18a3a457ca0a657f08cc4d0d43c6cf8953
+OSX_CROSS_COMMIT=d39ba022313f2d5a1f5d02caaa1efb23d07a559b
 OSXCROSS_PATH="/osxcross"
 
 LIBTOOL_VERSION=2.4.6
-OSX_CODENAME=yosemite
+OSX_CODENAME=el_capitan
 
 echo "Cloning osxcross"
 time git clone https://github.com/tpoechtrager/osxcross.git $OSXCROSS_PATH


### PR DESCRIPTION
Pushing here for easier sharing; I was trying if updating https://github.com/tpoechtrager/osxcross to a more recent version would solve the issue, then tried to add more dependencies (which were mentioned in that project's readme: https://github.com/tpoechtrager/osxcross/blob/d39ba022313f2d5a1f5d02caaa1efb23d07a559b/README.md

> ensure you have the following installed on your system:
>
> Clang 3.4+, cmake, git, patch, Python, libssl-devel (openssl)
> lzma-devel, libxml2-devel and the bash shell.
>
> You can run 'sudo tools/get_dependencies.sh' to get these (and the optional packages) automatically. (outdated)
>
> Optional:
> - llvm-devel: For Link Time Optimization support
> - llvm-devel: For ld64 -bitcode_bundle support
> - uuid-devel: For ld64 -random_uuid support

And added (YOLO) some of the dependencies that their (marked "outdated") `get_dependencies.sh` script installs; https://github.com/tpoechtrager/osxcross/blob/d39ba022313f2d5a1f5d02caaa1efb23d07a559b/tools/get_dependencies.sh#L43-L47