### PR TITLE
bump golang 1.12.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.12.10
+ARG GO_VERSION=1.12.11
 
 # OS-X SDK parameters
 # NOTE: when changing version here, make sure to also change OSX_CODENAME below to match

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.12.11
+ARG GO_VERSION=1.12.12
 
 # OS-X SDK parameters
 # NOTE: when changing version here, make sure to also change OSX_CODENAME below to match


### PR DESCRIPTION
based on top of https://github.com/docker/golang-cross/pull/46 - I'll rebase once that is merged, and create tags for both

full diff: https://github.com/golang/go/compare/go1.12.11...go1.12.12

go1.12.12 (released 2019/10/17) includes fixes to the go command, runtime,
syscall and net packages. See the Go 1.12.12 milestone on our issue tracker for
details.

https://github.com/golang/go/issues?q=milestone%3AGo1.12.12
