### PR TITLE
Update Golang 1.12.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.12.14
+ARG GO_VERSION=1.12.15
 
 # OS-X SDK parameters
 # NOTE: when changing version here, make sure to also change OSX_CODENAME below to match


### PR DESCRIPTION
full diff: https://github.com/golang/go/compare/go1.12.14...go1.12.15

go1.12.15 (released 2020/01/09) includes fixes to the runtime and the net/http
package. See the Go 1.12.15 milestone on the issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.12.15+label%3ACherryPickApproved
