### PR TITLE
Update Golang 1.12.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.12.16
+ARG GO_VERSION=1.12.17
 
 # OS-X SDK parameters
 # NOTE: when changing version here, make sure to also change OSX_CODENAME below to match


### PR DESCRIPTION
full diff: https://github.com/golang/go/compare/go1.12.16...go1.12.17

go1.12.17 (released 2020/02/12) includes a fix to the runtime. See the Go 1.12.17
milestone on the issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.12.17+label%3ACherryPickApproved
