### PR TITLE
Bump Golang 1.13.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.13.8
+ARG GO_VERSION=1.13.9
 
 # OS-X SDK parameters
 # NOTE: when changing version here, make sure to also change OSX_CODENAME below to match


### PR DESCRIPTION
go1.13.9 (released 2020/03/19) includes fixes to the go command, tools, the
runtime, the toolchain, and the crypto/cypher package. See the Go 1.13.9
milestone on the issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.13.9+label%3ACherryPickApproved

full diff: https://github.com/golang/go/compare/go1.13.8...go1.13.9
