### PR TITLE
Bump Golang 1.13.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.13.11
+ARG GO_VERSION=1.13.12
 
 # OS-X SDK parameters
 # NOTE: when changing version here, make sure to also change OSX_CODENAME below to match


### PR DESCRIPTION
go1.13.12 (released 2020/06/01) includes fixes to the runtime, and the go/types
and math/big packages. See the Go 1.13.12 milestone on the issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.13.12+label%3ACherryPickApproved

full diff: https://github.com/golang/go/compare/go1.13.11...go1.13.12