### PR TITLE
Bump Golang 1.13.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.13.13
+ARG GO_VERSION=1.13.14
 
 # OS-X SDK parameters
 # NOTE: when changing version here, make sure to also change OSX_CODENAME below to match


### PR DESCRIPTION
full diff: https://github.com/golang/go/compare/go1.13.13...go1.13.14

go1.13.14 (released 2020/07/16) includes fixes to the compiler, vet, and the
database/sql, net/http, and reflect packages. See the Go 1.13.14 milestone on
the issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.13.14+label%3ACherryPickApproved
