### PR TITLE
Bump Golang 1.13.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.13.14
+ARG GO_VERSION=1.13.15
 
 # OS-X SDK parameters
 # NOTE: when changing version here, make sure to also change OSX_CODENAME below to match


### PR DESCRIPTION
full diff: https://github.com/golang/go/compare/go1.13.14...go1.13.15

go1.13.15 (released 2020/08/06) includes security fixes to the encoding/binary
package. See the Go 1.13.15 milestone on the issue tracker for details.

https://github.com/golang/go/issues?q=milestone%3AGo1.13.15+label%3ACherryPickApproved
