### PR TITLE
Update to latest Go release (1.15.6)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.13.15
+ARG GO_VERSION=1.15.6
 
 # OS-X SDK parameters
 # NOTE: when changing version here, make sure to also change OSX_CODENAME below to match


### PR DESCRIPTION
This repository needs to be updated. It is several versions behind on an insecure Go version without the latest security fixes and improvements. This PR updates the version to 1.15.6 for all the goodies since the 1.13.x release.